### PR TITLE
Fetch all branches when preparing for keep-alive commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          git fetch origin # Fetch remote commits on all branches
           FIFTY_DAYS=4320000 # In seconds
           TIME_SINCE_COMMIT=$(expr $(date +%s) - $(git log --all -1 --format=%ct))
           if [ "$TIME_SINCE_COMMIT" -gt "$FIFTY_DAYS" ]; then


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&220726)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Turns out the call to `git log --all` was only considering `main` because the other remote branches were not fetched. _This will totally, 100% fix the problem for real this time and we won't need to revisit this again in two months 🤡_.