### PR TITLE
Simplify node setup by copying from the official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
-# ================ PYTHON
+ARG NODE_VERSION
 ARG PYTHON_VERSION
-FROM python:$PYTHON_VERSION
+FROM node:${NODE_VERSION} AS node_base
+FROM python:${PYTHON_VERSION}
+
+# Node and npm
+COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node_base /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_base /opt/yarn-* /opt/yarn
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn
+RUN ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN node --version && npm --version && yarn --version
 
 # System setup:
 RUN apt-get update \
@@ -10,21 +21,6 @@ RUN apt-get update \
 
 # Python context setup:
 RUN pip install --no-cache-dir --upgrade pip pip-tools
-
-# ================ NODE
-# https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-ARG NODE_VERSION
-RUN curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
-RUN apt-get install -y nodejs --no-install-recommends \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && node --version
-
-# Upgrade npm itself as the included version might be old
-RUN npm install --global npm@latest && npm --version
-
-# https://classic.yarnpkg.com/en/docs/install
-RUN npm install --global yarn && yarn --version
 
 # ================ ENVIRONMENT
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&0620)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

For some reason the build has been failing for the last few days, saying that `npm` wasn't installed. Instead of debugging that I just copied the `node`, `npm`, and `yarn` executables from the official image like we have been doing in other projects.