### PR TITLE
Build for node v20, drop node v14.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         suffix: ['', '-headless']
         python: ['3.12', '3.11', '3.10', '3.9']
-        node: ['18', '16', '14']
+        node: ['20', '18', '16']
     steps:
       - uses: actions/checkout@v4
       - name: Configure tag & caching


### PR DESCRIPTION
@jerivas I can't find any projects still using node v14 -- do you think it's still a bad idea to drop it here?