### PR TITLE
Expose corepack on Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM python:${PYTHON_VERSION}
 
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node_base /usr/local/lib/corepack /usr/local/lib/corepack
 COPY --from=node_base /usr/local/bin/node /usr/local/bin/node
 COPY --from=node_base /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node_base /opt/yarn-* /opt/yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ FROM python:${PYTHON_VERSION}
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node_base /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_base /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node_base /opt/yarn-* /opt/yarn
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn
 RUN ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
-RUN corepack enable
 RUN node --version && npm --version && yarn --version
 
 # System setup:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ FROM python:${PYTHON_VERSION}
 
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node_base /usr/local/lib/corepack /usr/local/lib/corepack
 COPY --from=node_base /usr/local/bin/node /usr/local/bin/node
 COPY --from=node_base /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node_base /opt/yarn-* /opt/yarn
+RUN ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ FROM python:${PYTHON_VERSION}
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node_base /usr/local/bin/node /usr/local/bin/node
-COPY --from=node_base /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node_base /opt/yarn-* /opt/yarn
 RUN ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn
 RUN ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN corepack enable
 RUN node --version && npm --version && yarn --version
 
 # System setup:


### PR DESCRIPTION
I'm not sure we want to enable Corepack by default on all images, but this at least exposes it so that individual projects can enable it if they like.